### PR TITLE
Improvements to setup scripts, library functions

### DIFF
--- a/autolaunch.py
+++ b/autolaunch.py
@@ -141,7 +141,7 @@ def set_build_path(options, dut):
              '/builds/'], timeout=3600)
         mdb.duts.update({'name': dut},
                         {'$set': {'build': '/builds/'+options.build}})
-    elif os.path.exists(options.build):
+    if os.path.exists(options.build):
         mdb.duts.update({'name': dut},
                         {'$set': {'build': options.build}})
         server_set = True
@@ -226,7 +226,10 @@ def do_test_suite(ops, recording, suite):
                                    reason=repr(sys.exc_info()[1]))
             recording.failed = True
         for i in range(num_steps):
-            if suite_results['step'+str(i)] == 'FAIL':
+            if 'step'+str(i) in suite_results.keys():
+                if suite_results['step'+str(i)] == 'FAIL':
+                    fail = True
+            else:
                 fail = True
         if fail:
             print 'INFO: Suite Failed.'
@@ -385,7 +388,8 @@ def launch():
             print "INFO: Running tests %s running on node %s" \
                   % (options.suites, n)
             dutdoc = mdb.duts.find_one({'name': node['name']})
-            set_build_path(options, node['name'])
+            if options.build is not None:
+                set_build_path(options, node['name'])
             thr.append(Process(target=suite_operation,
                        args=(options, node['name'])))
     except Exception:

--- a/bvt.py
+++ b/bvt.py
@@ -52,7 +52,7 @@ def list_test_cases(options):
     file_list = []
     for subdir, dirs, files in os.walk("./src/testcases"):
         for f in files:
-            if "__" not in f and "pyc" not in f:
+            if "__" not in f and f.endswith(".py"):
                 file_list.append(f)
     file_list.sort()
     for f in file_list:
@@ -109,6 +109,8 @@ def construct_arg_dict(options, test_parameters, result_id, handle):
             arg_dict[arg] = options.reason
         elif arg == 'encrypt_vhd' and options.encrypt_vhd:
             arg_dict[arg] = True if options.encrypt_vhd == "True" else False
+        elif arg == 'time' and options.time:
+            arg_dict[arg] = options.time
 
     if len(arg_dict) != handle.entry_fn.func_code.co_argcount:
         raise InvalidNumberOfArgumentsException()
@@ -216,6 +218,8 @@ def bvt():
                       'Functionality varies from test to test.')
     parser.add_option('-R', '--reason',  action='store',
                       help='Provide a reason for performing the test.')
+    parser.add_option('-T', '--time', metavar='TIME', action='store',
+                      help='set Time limit for time sensitive tests')
     options, args = parser.parse_args()
     if options.list_test_cases:
         list_test_cases(options)

--- a/bvt_daemon.py
+++ b/bvt_daemon.py
@@ -55,6 +55,7 @@ class BVTDaemon():
             proc = Popen(command, stdout=PIPE, stderr=PIPE, stdin=PIPE,
                          shell=False, cwd=None, env={})
             self.running.append((job, proc))
+
             mdb.jobs.update({'_id': objectid.ObjectId(job['_id'])},
                             {'$set': {'status': 'running'}})
 
@@ -92,7 +93,10 @@ class BVTDaemon():
                             {'_id': objectid.ObjectId(proc[0]['_id'])},
                             {'$set': {'status': 'queued'}})
                     else:
-                        logs = proc[1].communicate()
+                        try:
+                            logs = proc[1].communicate() # return code 6,7 causes ValueError: I/O operation on closed file
+                        except ValueError, logs:
+                            pass
                         self.log_messages(logs, proc)
                         if proc[1].returncode == 0:
                             mdb.jobs.update(

--- a/setup/00-install-prereqs.sh
+++ b/setup/00-install-prereqs.sh
@@ -4,10 +4,22 @@ echo "Installing required prereqs..."
 
 sudo apt-get update
 
-sudo apt-get install build-essential git python postgresql python-twisted conch python-psycopg2 python-pyasn1 python-setuptools python-docutils python-pymongo amtterm lftp
+sudo apt-get install build-essential git python postgresql python-twisted conch python-psycopg2 python-pyasn1 python-setuptools python-docutils python-nevow amtterm lftp
 
+# To get correct python-bson version (2.6.3-1build1)
+# Note: may need to remove already-installed version(s) of bson
+#[add Trusty main repo here and refresh/update]
+#sudo apt-get install python-bson=2.6.3-1build1
+
+sudo easy_install pymongo==2.2 # To get correct python-pymongo version (2.2): 
 sudo easy_install pysnmp
 sudo easy_install requests
+
+#Install amtctrl tool for wsman-only AMT versions
+git clone https://github.com/sdague/amt
+pushd amt
+sudo python setup.py install
+popd
 
 echo "Done!"
 #Setup python stuff

--- a/setup/03-install-dhcp-serv.sh
+++ b/setup/03-install-dhcp-serv.sh
@@ -41,7 +41,13 @@ if [[ $proceed == "True" && $exists == "False" ]]; then
     #Also need to alias in /etc/hosts
     echo "Make sure to alias the fixed addresses in /etc/hosts for test machines."
     echo "Done!"
+	echo "Setup will now install utilities to support DDNS (dnssec-tools and bind9).  Would you like to install these?"
+	proceed=$(prompt)
+	if [[ $proceed == "True" ]]; then
+		sudo apt-get install dnssec-tools bind9
+	else
+		echo "Skipping installation of dns utilities."
+	fi
 else
     echo "Skipping Installation and Configuration of ISC DHCP Server."
 fi
-

--- a/src/bvtlib/call_exec_daemon.py
+++ b/src/bvtlib/call_exec_daemon.py
@@ -44,7 +44,7 @@ def call_exec_daemon(command, args=list(), host=None, timeout=60, why=''):
           catch=[error])
 
 def run_via_exec_daemon(args, host, timeout=60, ignore_failure=False,
-                        split=False, echo=True, wait=True):
+                        split=False, word_split=False,line_split=False, echo=True, wait=True):
     """Run args on host.
 
     Fail after timeout.
@@ -94,8 +94,15 @@ def run_via_exec_daemon(args, host, timeout=60, ignore_failure=False,
     if exit_code != 0 and not ignore_failure:
         raise SubprocessError(exit_code, output[0], output[1])
     
-    output2 = [[line.split() for line in x.split('\n')] for 
-               x in output] if split else output 
+    if word_split:
+        output2 = [x.split() for x in output]
+    elif split: 
+        output2 = [[line.split() for line in x.split('\n')] for 
+               x in output]
+    elif line_split:
+        output2 = [x.split('\n') for x in output]
+    else:
+        output2 = output
     outv = output2[0]
     return (exit_code, outv) if ignore_failure else outv
 

--- a/src/bvtlib/device_ops.py
+++ b/src/bvtlib/device_ops.py
@@ -1,0 +1,21 @@
+#Contain operation of devices such as CD-rom
+from src.bvtlib.run import run
+from src.bvtlib.guest_ops import guest_uuid
+
+
+def get_cd_list(host):
+    #need to test on machine with mutiple cd drives to guarentee format of xec command
+    lines = run(['xec', '-o', '/host', 'list-cd-devices'], host=host, line_split=True)
+    cd_list=[]
+    id_lines=[]
+    for i in range(0,len(lines)/7):
+        id_lines.append(lines[i*7 + 1].strip())
+    for line in id_lines:
+        line = line.split('=')
+	cd_list.append(line[1][1:])
+    return cd_list
+
+def assign_cd(host, guest, device_id, uuid =""):
+    if uuid == "":
+        uuid = guest_uuid(host, guest)
+    run(['xec', '-o', '/host', 'assign-cd-device', device_id, "1", uuid], host=host,line_split=True)

--- a/src/bvtlib/disk_ops.py
+++ b/src/bvtlib/disk_ops.py
@@ -1,0 +1,174 @@
+from src.bvtlib.run import run
+
+class InformationCollectionFailure(Exception):
+    """failed to find needed information"""
+
+class BadEnumValue(Exception):
+    """Bad input value"""
+
+#returns disks in a list, returns None if empty
+def list_disks(host,guest):
+    disk_list = run(['xec-vm', '-n', guest, 'list-disks'], host=host, line_split=True)
+    if len(disk_list) < 1:
+        return None
+    if '' in disk_list:
+        disk_list.remove('')
+    return disk_list
+
+
+#returns the number of the disk on guest, None if no disks
+def parsed_list_disks(host,guest):
+    """returns the number of the disk on guest, None if no disks"""
+    unparsed = list_disks(host,guest)
+    if unparsed == None:
+        return None
+    parsed = []
+    for disk in unparsed:
+        partial = disk.split('/')
+        parsed.append(partial[-1].strip())
+    return parsed
+
+def last_disk(host, guest):
+    """gives last disk, if no disks returns None"""
+    disk_list = parsed_list_disks(host,guest)
+    if disk_list == None:
+        return None
+    return disk_list[-1]
+
+def is_vhd(host,guest,disknum):
+    """see if a disk is a vhd"""
+    disk_type = run(['xec-vm', '-n', guest, '--disk' , disknum, 'get', 'phys-type'],host=host).strip()
+    if disk_type == 'vhd':
+        return True
+    return False
+
+def is_vhd_valid(host,guest,disknum):
+    """see if a vhd is valid, will return False if in use"""
+    if not is_vhd(host,guest,disknum):
+        return False
+    phy_path = run(['xec-vm', '-n', guest, '--disk', disknum, 'get', 'phys-path'],host=host).strip()
+
+    result = run(['vhd-util', 'check', '-n', phy_path],host=host,ignore_failure=True)
+    if result[0].strip() == phy_path + ' is valid':
+        return True
+    return False
+
+def list_vhd(host, guest):
+    """finds all vhd on a guest returns the disk nums that are vhd"""
+    disks = parsed_list_disks(host,guest)
+    vhd_list = []
+    for disknum in disks:
+         if is_vhd(host, guest, disknum):
+             vhd_list.append(disknum)
+    return vhd_list
+
+def add_disk(host, guest):   
+    return run(['xec-vm', '-n', guest, 'add-disk'], host=host)
+
+def list_vhd_by_name(host,guest):
+    disk_nums = list_vhd(host,guest)
+    name_list = []
+    for disk in disk_nums:
+        path = run(['xec-vm', '-n', guest, '--disk', disk, 'get', 'phys-path'], host=host).strip()
+        name_list.append(path.split('/')[-1].strip())
+    return name_list
+
+def parsed_add_disk(host, guest):
+    """returns the number of the disk instead of disk path"""
+    unparsed = add_disk(host,guest)
+    parsed = unparsed.split('/')
+    return parsed[-1].strip()
+
+def add_vhd(host, name, size = 80000):
+    #returns the path to the disk
+    run(['vhd-util', 'create', '-n', '/storage/disks/' + name, '-s', str(size)],host=host)
+    return '/storage/disks/' + name
+
+def create_snapshot(host,path,vhd_path):
+    run(['vhd-util', 'snapshot', '-n', path, '-p', vhd_path],host=host) 
+
+def attach_vhd(host,guest,disknum,path):
+    run(['xec-vm', '-n', guest, '--disk', disknum, 'attach-vhd', path],host=host)
+
+def disk_type(host, guest, disknum):
+    return run(['xec-vm', '-n', guest, '--disk', disknum, 'get', 'mode'],host=host).strip()
+
+def get_disk_snapshot(host,guest,disknum):
+    return run(['xec-vm', '-n', guest, '--disk', disknum, 'get', 'snapshot'],host=host).strip()
+
+def set_disk_devtype(host,guest, disknum, devtype):
+    run(['xec-vm', '-n', guest, '--disk', disknum, 'set', 'devtype', devtype], host=host)
+
+def set_disk_mode(host, guest, disknum, mode):
+    run(['xec-vm', '-n', guest, '--disk', disknum, 'set', 'mode', mode], host=host)
+
+def get_disk_phys_path(host,guest, disknum):
+    return (['xec-vm','-n' , guest, '--disk', 'get' ,'phys-path']).strip()
+
+def set_disk_phys_path(host, guest, disknum, path):
+    run(['xec-vm', '-n', guest, '--disk', disknum, 'set', 'phys-path', path], host=host)
+
+def set_disk_phys_type(host, guest, disknum, phys_type):
+    run(['xec-vm', '-n', guest, '--disk', disknum, 'set', 'phys-type', phys_type], host=host)
+
+def set_disk_snapshot(host, guest, disknum, snapshot):
+    #should be none or temporary
+    if  snapshot != 'none' and snapshot != 'temporary':
+        raise BadEnumValue() 
+    run(['xec-vm', '-n', guest, '--disk', disknum, 'set', 'snapshot', snapshot],host=host)
+
+def delete_disk(host,guest, disknum):
+    run(['xec-vm', '-n', guest, 'shutdown'], host=host)
+    run(['xec-vm', '-n', guest, '--disk', disknum, 'delete'], host=host)
+
+def guest_iso_list(host):
+    """lists isos in /storage/isos assumes no random files make their way in here"""
+    unparsed = run(['ls', '/storage/isos'],host=host, word_split=True)
+    iso_list = []
+    for iso in unparsed:
+        if iso != '':
+            iso_list.append(iso.strip())
+    return iso_list
+
+def guest_iso_volume_id_list(host):
+    """gets the volume id of the iso, how vm shows the iso"""
+    guest_iso_list = guest_iso_list(host)
+    volume_list = []
+    correct_line = None
+    for iso in guest_iso_list:
+        unparsed = run(['isoinfo', '-d', '-i', '/storage/isos/' + iso],host=host,line_split=True)
+        for line in unparsed:
+            if 'Volume' in line and 'id' in line:
+                correct_line = line.strip()
+                break
+        if correct_line == None:
+            raise InformationCollectionFailure()
+        parse_two = correct_line.split(" ")
+        volume_id = parse_two[-1].strip()
+        volume_list.append(correct_line.split(" ")[-1].strip())
+    return volume_list
+        
+def iso_volume_id(host, iso):
+    """returns volume_id, which is name of it in VM"""
+    unparsed = run(['isoinfo', '-d', '-i', '/storage/isos/' + iso],host=host,line_split=True)
+    for line in unparsed:
+        if 'Volume' in line and 'id' in line:
+            parse_one = line.strip()
+            break
+    parse_two = parse_one.split(" ")
+    volume_id = parse_two[-1].strip()
+    if volume_id == 'OpenXT-tools':
+        volume_id = 'OpenXT-tool'
+    return volume_id
+
+def guest_iso_0(host,guest):
+    """gets what iso is held in the 0 disk slot of a VM"""
+    unparsed = run(['xec-vm', '-n', guest, '--disk', '0', 'get', 'phys-path'],host=host).strip().split('/')
+    #parsed = unparsed.split('/')
+    iso_0 = unparsed[-1]
+    return iso_0.strip()
+
+def set_iso_0(host,guest,iso):
+    """sets what iso is held in the 0 disk slot of a VM"""
+    run(['xec-vm', '-n', guest, '--disk', '0', 'set', 'phys-path', '/storage/isos/'+iso],host=host)
+

--- a/src/bvtlib/guest_info.py
+++ b/src/bvtlib/guest_info.py
@@ -17,13 +17,70 @@
 #
 
 """Provide information about guest"""
-
 from src.bvtlib.run import run
 
 def get_system_type(host, guest):
     out = run(['xec-vm', '-n', guest, 'get', 'os'], host=host)
     return out.strip()
 
+def set_system_type(host, guest, os):
+    run(['xec-vm', '-n', guest, 'set', 'os', os], host=host)
+
+def remove_extra_vms(host, vm_list):
+    #removes ndvms and uivm from the returned list
+    neat_list =[]
+    for vm in vm_list:
+        if vm == '00000000-0000-0000-0000-000000000001':
+            pass
+        elif 'true' == run(['xec-vm', '-u', vm ,'get', 'provides-network-backend'], host=host).strip():
+            pass
+        else:
+            neat_list.append(vm)
+    return neat_list
+
+def list_vms_uuid(host, remove_extra=True):
+    #if you want to avoid nvdm and uivm remove_extra should be true
+    vm_list = run(['xec', 'list-vms'], host=host, line_split=True)
+    for i in range(0, len(vm_list)):
+    #commands makes it start with /vm/ so getting rid of that
+    #also since returning files has _ instead of - 
+        vm_list[i] = vm_list[i][4:].replace('_', '-')
+    for vm in vm_list:
+        if vm == '':
+            vm_list.remove(vm)
+    if remove_extra:
+        vm_list = remove_extra_vms(host, vm_list)
+    return vm_list
+
+def list_vms_by_name(host):
+    vm_list = list_vms_uuid(host,remove_extra=False)
+    vm_list_name = []
+    for vm in vm_list:
+        vm_name = run(['xec-vm', '-u', vm, 'get', 'name'],host=host).strip()
+        if vm_name != '':
+            vm_list_name.append(vm_name)
+    return vm_list_name
+
+def list_domids(host):
+    domid_list = run(['xec', 'list-domids'],host=host, line_split=True)
+    if '' in domid_list:
+        domid_list.remove('')
+    return domid_list
+
+def list_ndvms(host):
+    vm_list = list_vms_name(host)
+    ndvm_list = []
+    for guest in vm_list:
+        if guest_provides_network_backend(host,guest):
+            ndvm_list.append(guest)
+    return ndvm_list
+
+def list_domids_from_name_list(host,name_list):
+    domid_list = []
+    for name in name_list:
+        domid_list.append(guest_domid(host,name))
+    return domid_list
+   
 def get_default_exec_method(host, guest):
     system = get_system_type(host, guest)
     if system == "windows":
@@ -33,3 +90,76 @@ def get_default_exec_method(host, guest):
     else:
         raise Exception("No default exec method for %s" % system)
 
+def guest_acpi_state(host,guest, uuid=None):
+    return run(['xec-vm','-n',guest,'get','acpi-state'],host=host).strip()
+
+def is_acpi_state(host,guest,state):
+    acpi_state = int(guest_acpi_state(host,guest))
+    if acpi_state == state:
+        return True
+    return False
+
+def guest_name_from_uuid(host,uuid):
+    name = run(['xec-vm', '-u', uuid, 'get', 'name'],host=host).strip()
+    return name
+
+def guest_uuid_from_name(host,name):
+    uuid = run(['xec-vm', '-n', name, 'get', 'uuid'],host=host).strip()
+    return uuid
+ 
+def guest_ram(host,guest):
+    ram = int(run(['xec-vm', '-n', guest, 'get', 'memory'],host=host).strip())
+    return ram
+
+def guest_vcpu(host,guest):
+    vcpu = int(run(['xec-vm', '-n', guest, 'get', 'vcpus'],host=host).strip())
+    return vcpu
+
+def guest_boot_order(host,guest):
+    boot_order = run(['xec-vm', '-n', guest, 'get', 'boot'],host=host).strip()
+    return boot_order
+
+def guest_stubdom(host,guest):
+    stubdom = run(['xec-vm', '-n', guest, 'get', 'stubdom'],host=host).strip()
+    return stubdom
+
+def guest_domid(host,guest):
+    domid = run(['xec-vm', '-n', guest, 'get', 'domid'],host=host).strip()
+    return int(domid)
+
+def guest_provides_network_backend(host,guest):
+    backend = run(['xec-vm', '-n', guest, 'get', 'provides-network-backend'],host=host).strip()
+    if backend == 'true':
+        return True
+    return False
+
+def get_num_domain_ids(host):
+    """retrieves number of domain ids, including stubdoms"""
+    unparsed = run(['xenops', 'list_domains'],host=host,line_split=True)
+    return len(unparsed)-2
+    #one for the info line, and one for the empty string at the end
+
+def get_largest_domid(host):
+    """gets largetest active dom ID, which might not be largest one used"""
+    unparsed = run(['xenops', 'list_domains'],host=host,line_split=True)
+    first_parse = []
+    for line in unparsed:
+        first_parse.append(line.split('|'))
+    for line in first_parse:
+        if line[0].strip() == '' or line[0].strip() == 'id':
+            first_parse.remove(line)
+    domids = []
+    for line in first_parse:
+        domids.append(int(line[0].strip()))
+    print "DEBUG: returning %d as highest domid" % max(domids)
+    return max(domids)
+
+def get_num_vms(host):
+    return len(list_vms_uuid(host))
+
+def guest_tools(host,guest):
+    tools = run(['xec-vm', '-n', guest, 'get', 'pv-addons'],host=host).strip()
+    if tools == 'true':
+        return True
+    else: 
+        return False

--- a/src/bvtlib/guest_ops.py
+++ b/src/bvtlib/guest_ops.py
@@ -1,6 +1,28 @@
 #!/usr/bin/python
-from src.bvtlib.run import run
 
+from src.bvtlib.disk_ops import create_snapshot, is_vhd_valid
+from src.bvtlib.guest_info import is_acpi_state, get_system_type, set_system_type, get_largest_domid
+from src.bvtlib.run import run
+from src.bvtlib.wait_for_guest import wait_for_guest
+from src.bvtlib.call_exec_daemon import run_via_exec_daemon, call_exec_daemon
+from src.bvtlib.domains import domain_address
+from src.bvtlib.settings import VALID_OS_TYPES
+import re
+
+class InvalidBootOrder(Exception):
+    """Invalid Boot symbol"""
+
+class UnExpectedOs(Exception):
+    """Not a valid os for the operation"""
+
+class InformationCollectionFailure(Exception):
+    """Unable to collect required information"""
+
+class UnableToSetOSType(Exception):
+    """Unable to confirm OS is set to expected type"""
+
+class UnableToDetermineOSFromVHD(Exception):
+    """Unable to deteremine OS from VHD from valid OS types"""
 
 def parse_leases():
     out = []
@@ -28,6 +50,39 @@ def get_vm_ip(host, name):
         if mac == entry[0]:
             return entry[1]
     return None
+
+def get_architecture(host,guest):
+   if not is_acpi_state(host,guest,0):
+       guest_start(host,guest)
+       guest_switch(host,guest)
+       wait_for_guest(host,guest)
+   os = get_system_type(host,guest)
+
+   if os == 'windows':
+       unparsed = run_via_exec_daemon(['systeminfo'], host=domain_address(host,guest),line_split=True)
+       for line in unparsed:
+           if "System Type" in line:
+               correct_line = line.split(" ")
+               break
+       if correct_line == None:
+           print "ERR: Architecture not returned"
+           raise InformationCollectionFailure()
+       temp = correct_line
+       correct_line = None
+       for seg in temp:
+           if any(char.isdigit() for char in seg):
+               correct_line = seg
+               break
+       if correct_line == None:
+           print "ERR: Architecture not returned"
+           raise InformaitonCollectionFailure()
+       Arch = re.sub("\D", "", correct_line)
+       return Arch.strip()
+
+   elif os == 'linux':
+       return run(['uname','-m'],host=domain_address(host,guest),ignore_failure=True)[0].strip() 
+   else:
+       raise UnexpectedOs() 
 
 def create_guest(host, name, desc, memory='6144', vcpus='2', encrypt=False, os='linux', 
                     vhd=None, iso=None):
@@ -64,20 +119,47 @@ def create_guest(host, name, desc, memory='6144', vcpus='2', encrypt=False, os='
         run(['xec-vm', '-n', name, '-k', dn, 'attach_vhd', v_path], host=host)
     if encrypt:
         key_dir = run(['xec', 'get', 'platform-crypto-key-dirs'],
-                      host=dut, line_split=True)[0]
-        run(['mkdir', '-p', key_dir], host=dut)
+                      host=host, line_split=True)[0]
+        run(['mkdir', '-p', key_dir], host=host)
         phys_path = run(['xec-vm', '-n', name, '--disk', '1',
-                        'get', 'phys-path'], host=dut, line_split=True)[0]
+                        'get', 'phys-path'], host=host, line_split=True)[0]
         assert basename(phys_path).endswith('.vhd')
         vm_vhd_uuid = basename(phys_path)[:-4]
         key_file = (key_dir + '/'+vm_vhd_uuid+',aes-xts-plain,'+
                     '512.key')
         run(['dd', 'if=/dev/urandom', 'of='+key_file,
              'count='+512/8, 'bs=1'],
-            host=dut)
+            host=host)
         run(['vhd-util', 'key', '-n', phys_path, '-k', key_file, '-s'],
-            host=dut)
+            host=host)
     return name
+
+def create_vm_from_template(host,template):
+    #create vm using template
+    path = run(['xec', 'create-vm-with-template', '/usr/share/xenmgr-1.0/templates/default/' + template],host=host).strip()
+    parsed = path.split('/')
+    uuid = parsed[-1]
+    return uuid.replace('_','-')
+
+
+def create_vm_and_snapshot(host, name, desc, base_vhd_path, snapshot_name, memory='6144', vcpus='2', encrypt=False, os='windows'):
+    snapshot_path = '/storage/disks/' + snapshot_name
+    create_snapshot(host,snapshot_path,base_vhd_path)
+    create_guest(host, name, desc, memory, vcpus, encrypt, os, vhd=snapshot_path)
+    return name
+
+def vm_clean_up_deletion(host,guest):
+    """quickly and almost guarentee vm will get deleted"""
+    guest_destroy(host,guest)
+    guest_delete(host,guest)
+ 
+def get_largest_domid_with_guest(host):
+    """creates a temp guest to get the current largest used domid"""
+    guest = create_guest(host, "largest_domid_guest", "guest to check largest domid", memory='2048')
+    guest_start(host,guest)
+    max_domid = get_largest_domid(host)
+    vm_clean_up_deletion(host,guest)
+    return max_domid
 
 #Default to blocking on these operations, but support the ability
 #to not block.
@@ -85,14 +167,45 @@ def guest_start(host, name, wait=True):
     run(['xec-vm', '-n', name, 'start'], host=host, wait=wait)
 
 def guest_shutdown(host, name, wait=True):
-    run(['xec-vm', '-n', name, 'shutdown'], host=host, wait=wait)
+    run(['xec-vm', '-n', name, 'shutdown'], host=host, wait=wait,timeout = 150.0)
 
 def guest_destroy(host, name, wait=True):
     run(['xec-vm', '-n', name, 'destroy'], host=host, wait=wait)
 
+#Default to using name, but support using uuid instead
 def guest_delete(host, name):
     if guest_state(host, name) == 'stopped':
         run(['xec-vm', '-n', name, 'delete'], host=host)
+    else:
+        print "ERR: GUEST " + str(name) + " not deleted"
+
+def guest_reboot(host,name):
+    run(['xec-vm', '-n', name, 'reboot'],host=host)
+
+def guest_switch(host,name):
+    run(['xec-vm','-n', name, 'switch'],host=host)
+
+def guest_pause(host, name):
+    run(['xec-vm', '-n', name, 'pause'], host=host)
+
+def set_boot_order(host,name,order):
+    #would check exclusive, but makes an easy check
+    valid_boot = ['c','d','n']
+    for letter in order:
+        if letter not in valid_boot:
+            raise InvalidBootOption()
+    run(['xec-vm', '-n', name, 'set', 'boot', order], host=host)
+
+def set_memory(host,name, memory):
+    run(['xec-vm', '-n', name, 'set', 'memory', memory], host=host)
+
+def set_vcpu(host,name, vcpu):
+    run(['xec-vm', '-n', name, 'set', 'vcpus', vcpu], host=host)
+
+def set_stubdom(host,name,stubdom):
+    run(['xec-vm', '-n', name, 'set', 'stubdom', stubdom],host=host)
+
+#below this line might want to move to guest_info
 
 def guest_uuid(host, name, clean=False):
     try:
@@ -105,8 +218,8 @@ def guest_uuid(host, name, clean=False):
         return None
     
     
-def guest_exists(host, name):
-    uuid = guest_uuid(host, name)
+def guest_exists(host, name, clean=True):
+    uuid = guest_uuid(host, name, clean=clean)
     if uuid is None:
         return False
     out = run(['xec', 'list-vms'], host=host, line_split=True)
@@ -116,4 +229,86 @@ def guest_exists(host, name):
     return False
 
 def guest_state(host, name):
-    return run(['xec-vm', '-n', name, 'get', 'state'], host=host, line_split=True)
+    return run(['xec-vm', '-n', name, 'get', 'state'], host=host, line_split=True)[0]
+        
+def guest_domid(host, name):
+    return int(run(['xec-vm', '-n', name, 'get', 'domid'], host=host).strip())
+
+def guest_type(host, name):
+    return run(['xec-vm', '-n', name, 'get', 'type'], host=host).strip()
+
+#copied over to get info, delete once all references to it are moved over
+def guest_acpi_state(host, name):
+    return run(['xec-vm', '-n', name, 'get', 'acpi-state'], host=host)
+
+def get_os_from_vhd(host,vhd_path):
+    """given a local vhd path, determine if its running windows or linux"""
+    #loop through given os types in global VALID_OS_TYPES setting and see if we can get it to respond properly
+    guest_is = None
+    guest_name = create_vm_and_snapshot(host=host, name='get_os_from_vhd_test',desc="get_os_from_vhd_test_desc", base_vhd_path=vhd_path,snapshot_name='get_os.vhd', memory='2048', vcpus='2', encrypt=False, os=VALID_OS_TYPES[0])
+    is_vhd_valid(host,guest_name,"1")
+    #for os in (os for os in VALID_OS_TYPES if guest_is == None):
+    for os in VALID_OS_TYPES:
+        print "DEBUG: testing os: \"%s\"" % os
+        curr_system_type = None
+        set_system_type(host,guest_name,os)
+        curr_system_type = get_system_type(host,guest_name)
+        if os != curr_system_type:
+            raise UnableToSetOSType("unable to confirm os_type \"%s\" is the same as type to test: \"%s\"" % (curr_system_type, os)) 
+        guest_start(host,guest_name)
+        try:
+            wait_for_guest(host,guest_name,timeout=120)
+        except:
+            print "DEBUG: VM: \"%s\" did not respond as a %s guest" % (guest_name,os)
+        else:
+            print "DEBUG: assigning current OS to system as determined to be it: \"%s\"" % (os)
+            guest_is = os
+            break
+
+    vm_clean_up_deletion(host,guest_name)
+    print "guest is: \"%s\"" % guest_is
+    if guest_is in VALID_OS_TYPES:
+        print "DEBUG: given vhd was of OS type: %s" % guest_is 
+        return guest_is 
+    else:
+        print "ERROR: could not determine OS from vhd: %s" % (vhd_path)
+        raise UnableToDetermineOSFromVHD("unable to deteremine OS from VHD from valid OS types")
+
+
+def guest_disk_count(host,guest):
+    """function to get the count of 'disks' the guest sees"""
+    total_disk_count = 0
+    os = get_system_type(host,guest)
+    if os == 'windows':
+        unparsed = run_via_exec_daemon(['echo', 'list', 'disk', '|', 'diskpart','|','find','"Disk"','|','find','"Online"'],host=domain_address(host, guest, timeout=5),line_split=True)
+        #necessary as windows sometimes puts random blank lines at the end
+        print "DEBUG: "+',,'.join(unparsed)
+        for entry in unparsed:
+            if "Disk" in entry:
+                total_disk_count += 1
+    elif os == 'linux':
+        unparsed = run(['lsblk','-l','-o','NAME,TYPE'], host=domain_address(host, guest, timeout=5), timeout=20, check_host_key=False, line_split=True)
+        for entry in unparsed:
+            if "disk" in entry:
+                total_disk_count += 1
+    else:
+        raise UnexpectedOs() 
+
+    print "DEBUG: returning guest: \"%s\" has %d disks" % (guest,total_disk_count)
+    return total_disk_count
+
+def disable_start_on_boot(host,guest):
+    """function to set the start-on-boot attribute per guest to false"""
+    run(['xec-vm', '-n', guest, 'set', 'start-on-boot', 'false'], host=host)
+
+def enable_start_on_boot(host,guest):
+    """function to set the start-on-boot attribute per guest to true"""
+    run(['xec-vm', '-n', guest, 'set', 'start-on-boot', 'true'], host=host)
+    
+def get_start_on_boot(host,guest):
+    """function to get the start-on-boot attribute per guest"""
+    return run(['xec-vm', '-n', guest, 'get', 'start-on-boot'], host=host)
+
+def get_username(host,guest,addr,os):
+    if os == 'windows':
+        return run_via_exec_daemon(['whoami'], host=addr).split('\\')[1].strip('\n')

--- a/src/bvtlib/host_ops.py
+++ b/src/bvtlib/host_ops.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+from src.bvtlib import mongodb
+from src.bvtlib.run import run, specify
+from src.bvtlib.retry import retry
+
+def get_bus(dut):
+    """Query mongo for the bus of secondary nic.  If it isn't there, assume
+        nic is on bus 01."""
+    mdb = mongodb.get_autotest()
+    dut_doc = mdb.duts.find_one({'name': dut})
+    if dut_doc.get('nic-bus'):
+        return dut_doc['nic-bus']
+    else:
+        return "01"
+
+def mount_debugfs(host):
+    run(['mount', '-t', 'debugfs', 'none', '/sys/kernel/debug'], host=host)
+
+def is_debugfs_mounted(host):
+    out = run(['ls', '-A', '/sys/kernel/debug'], host=host).strip()
+    if out != "":
+        return True
+    return False
+
+def get_vhd_from_url(host, url):
+    """Return the path to the vhd. If it doesn't exist, bvt will download it from
+       the provided url"""
+    split = url.split('/')
+    name = split[len(split)-1]
+    job = specify(host=host)
+    _, result = run(['ls', '/storage/disks/'+name], host=host, ignore_failure=True)
+    if result > 0:
+        retry(lambda: job(['wget', '-q', '-O', '/storage/disks/'+name, url], timeout=3600), timeout=7200, description='download'+url)
+    return '/storage/disks/'+name
+
+def host_reboot(host):
+    run(['reboot'], host=host)
+
+def does_template_exist(host,template):
+    #fn to confirm if template exists in the template directory of the host
+    template_list = run(['find','/usr/share/xenmgr-1.0/templates/default','-type','f','-exec', 'basename','{}',';'],host=host,line_split=True)
+    for host_template in template_list:
+        if template in host_template:
+            print "DEBUG: template %s exists on host" % template
+            return True
+    return False
+    

--- a/src/bvtlib/install_tools_windows.py
+++ b/src/bvtlib/install_tools_windows.py
@@ -40,6 +40,7 @@ from src.bvtlib.install_dotnet import install_dotnet
 from src.bvtlib.windows_guest import make_tools_iso_available
 from src.bvtlib.domains import domain_address
 from src.bvtlib.exceptions import UnableToInstallTools, ToolsAlreadyInstalled
+from src.bvtlib.guest_ops import get_username
 
 class ToolsIsoMissing(Exception):
     """Tools ISO not found in dom0"""
@@ -290,9 +291,10 @@ def install_dev_certs(dut, dev, domain, vm_address):
         run_via_exec_daemon(['bcdedit','/set', 'testsigning', 'on'], host=vm_address)
         reboot_windows(dut, domain, vm_address)
         wait_for_windows(dut, domain['name'])
-        call_exec_daemon('fetchFile', ['http://openxt.ainfosec.com/certificates/windows/developer.cer', 'C:\\Users\\bvt\\developer.cer'], host=vm_address, timeout=300)
-        run_via_exec_daemon(['certutil -addstore -f "Root" C:\\Users\\bvt\\developer.cer'], host=vm_address)
-        run_via_exec_daemon(['certutil -addstore -f "TrustedPublisher" C:\\Users\\bvt\\developer.cer'], host=vm_address)
+        username = get_username(dut,domain,vm_address,'windows')
+        call_exec_daemon('fetchFile', ['http://openxt.ainfosec.com/certificates/windows/developer.cer', 'C:\\Users\\%s\\developer.cer'% username], host=vm_address, timeout=300)
+        run_via_exec_daemon(['certutil -addstore -f "Root" C:\\Users\\%s\\developer.cer'% username], host=vm_address)
+        run_via_exec_daemon(['certutil -addstore -f "TrustedPublisher" C:\\Users\\%s\\developer.cer'% username], host=vm_address)
     except Exception:
         print "ERROR: Failure to install developer certs."
         print_exc()

--- a/src/bvtlib/record_test.py
+++ b/src/bvtlib/record_test.py
@@ -133,7 +133,7 @@ class RecordTest:
         """Start recording a test"""
         try:
             run(['logger', 'BVT', 'starting', self.full_description()], 
-                host=self.dut, timeout=2)
+                host=self.dut, timeout=10)
         except SubprocessError:
             print 'INFO: unable to mark test log'
         if not self.record:

--- a/src/bvtlib/run.py
+++ b/src/bvtlib/run.py
@@ -293,11 +293,11 @@ def writefile(filename, content, host=None, user='root', via_root=False,
         return
     try:
         if via_root:
-            run(['scp', temp, 'root@'+host+':'+filename], env=None,
+            run(['scp', '-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null', temp, 'root@'+host+':'+filename], env=None,
                 **args)
             run(['chown', user, filename], user='root', host=host)
         else:
-            run(['scp', temp, user+'@'+host+':'+filename], env=None,
+            run(['scp', '-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null', temp, user+'@'+host+':'+filename], env=None,
                 **args)
     finally:
         unlink(temp)

--- a/src/bvtlib/settings.py
+++ b/src/bvtlib/settings.py
@@ -247,6 +247,7 @@ ENABLE_BW_TEST = True #Tell build_watcher to queue jobs on new builds by default
 PRINT_AVC = False #log avc denials by default but provides option to disable to avoid log clutter
 # You will need to override some settings here, so rather than force users
 # to modify this file we require everyone have a private_settings.py file
+VALID_OS_TYPES = ["linux", "windows"]
 from private_settings import *
 
 # DO NOT ADD DECLARATIONS HERE; add them before the private_settings block above

--- a/src/bvtlib/xen_info.py
+++ b/src/bvtlib/xen_info.py
@@ -1,0 +1,16 @@
+#for operations about xen
+
+from src.bvtlib.run import run
+
+
+def total_mem(host):
+    unparsed = run(['xenops', 'physinfo'],host=host,line_split=True)
+    for line in unparsed:
+        if "total_pages" in line:
+            return int(line.split('(')[1].split(' ')[0])
+
+def free_mem(host):
+    unparsed = run(['xenops', 'physinfo'],host=host,line_split=True)
+    for line in unparsed:
+        if 'free_pages' in line:
+            return int(line.split('(')[1].split(' ')[0])

--- a/src/testcases/cd_exclusive_test.py
+++ b/src/testcases/cd_exclusive_test.py
@@ -1,0 +1,91 @@
+#assumes list of cds is decently short as check currently uses N^2 algorthim
+#check to make sure passthrough of cds is exclusive
+#get_cd_list not guarenteed with multiple cds
+#tries to assign all cd's to every VM, and after each assign checks the intergrity
+
+
+
+from src.bvtlib.run import run
+from src.bvtlib.guest_info import list_vms_uuid
+from src.bvtlib.device_ops import get_cd_list, assign_cd
+from src.bvtlib.guest_ops import create_vm_and_snapshot, vm_clean_up_deletion
+from src.bvtlib.host_ops import get_vhd_from_url
+import random
+from time import sleep
+
+
+class MultiCDAssign(Exception):
+    """A CD is assigned to mutiple VMs"""
+
+class NotEnoughVMToTest(Exception):
+    """Either 1 or 0 VMs so impossible for a cd to be assigned to multiple"""
+
+
+def rand_assign(host, cd_list, vm_list):
+    for cd in cd_list:
+        for i in range(0,9):
+            vm = (random.choice(vm_list))
+            assign_cd(host, '', cd, vm)
+            exclusive(host)
+
+def exclusive(host):
+   
+    lines = run(['db-ls', '/xenmgr/cdassign/'], host=host,line_split=True)
+    #lines = block.splitlines()
+    #due to how db-ls works first line is unimportant
+    del lines[0]
+    split = []
+    for lastspot, cd in enumerate(lines):
+        if cd != '':
+        #due to how line_split is
+            split.append(cd.split('='))
+            #split[*][0] hold cd id
+            #split[*][1] hold uuid of vm it is assigned to
+            for obj in split:
+                if obj[0] == split[lastspot][0]:
+                    if obj[1] != split[lastspot][1]:
+                        raise MultiCDAssign(split)
+    return True
+
+def standard_assign(host, cd_list, vm_list):
+    for cd in cd_list:
+        for vm in vm_list:
+            assign_cd(host, '', cd, vm)
+            exclusive(host)
+
+def cd_exclusive_test(host, vhd_url):
+    
+    try:
+        exclusive(host)
+        guest = 'exclusive-1'
+        guest2 = 'exclusive-2'
+        path = get_vhd_from_url(host, vhd_url)
+
+        name1 = create_vm_and_snapshot(host, guest, 'Test vm', path, 'exclusive-cd-snap.vhd')
+        name2 = create_vm_and_snapshot(host, guest2, 'Test vm', path, 'exclusive-cd-snap2.vhd')
+
+        cd_list = get_cd_list(host)
+        vm_list = list_vms_uuid(host)
+        if len(vm_list) <= 1:
+            raise NotEnoughVMToTest()
+
+        #try to assign each cd to all vm's, see if it breaks
+        standard_assign(host,cd_list,vm_list)
+        #just throw around random assigns to see if CD can get assigned to 2.
+        rand_assign(host,cd_list,vm_list)
+
+        if exclusive(host):
+            print "Mutually exclusive kept, test succeeded"
+    except:
+        raise
+
+    finally:
+        vm_clean_up_deletion(host, guest)
+        vm_clean_up_deletion(host, guest2)
+    
+
+def entry_fn(dut, url):
+    cd_exclusive_test(dut, url) 
+
+def desc():
+    return "check to make sure passthrough of cd is exclusively locking, only one VM can have a cd at a time"

--- a/src/testcases/sleep_test.py
+++ b/src/testcases/sleep_test.py
@@ -1,0 +1,128 @@
+#method is based off OXT-137 repro instructions
+#might as well add in linux verison as well later
+#After making sure VM is running, makes it sleep from dom0
+#then it makes it sleep from within VM
+#then attempts to shutdown from sleep
+
+
+
+
+
+from src.bvtlib.run import run
+from time import sleep
+from src.bvtlib.retry import retry
+from src.bvtlib.guest_info import get_system_type, is_acpi_state, guest_acpi_state
+from src.bvtlib.guest_ops import guest_destroy, guest_delete, guest_exists, guest_state, guest_shutdown, create_vm_and_snapshot
+from src.bvtlib.start_vm import start_vm_if_not_running
+from src.testcases.install_guest import install_guest
+from src.bvtlib.install_tools_windows import install_tools
+from src.bvtlib.wait_to_come_up import wait_to_come_up
+from src.bvtlib.call_exec_daemon import call_exec_daemon
+from src.bvtlib.windows_transitions import vm_sleep_self, vm_reinstate_hibernate, vm_poweron, vm_resume
+from src.bvtlib.host_ops import get_vhd_from_url
+
+
+
+
+class VMSleepFailure(Exception):
+    """the VM didn't properly go into sleep mode"""
+
+class VMResumeFailure(Exception):
+    """the VM failed to resume from sleep"""
+
+class VMShutdownFailure (Exception): 
+    """the VM wouldn't shutdown"""
+
+class VMDeletionFailure(Exception): 
+    """The VM didn't get deleted"""
+
+class URLNotSetException(Exception):
+    """Required Global for set up is not set"""
+
+
+def is_asleep(host,guest):
+    #used to assert the host has entered the sleep state
+    if is_acpi_state(host,guest,3):
+        return True
+    else:
+        raise VMSleepFailure()
+
+def sleep_dom0(host,guest):
+    #depending on the status changing of the host before it sleep might fail first time
+    retry(
+        lambda: run(['xec-vm', '-n', guest, 'sleep'], host=host),
+        description = 'xec-vm sleep on VM',
+        timeout = 120)
+    is_asleep(host,guest)
+
+    """Wake Vm up"""
+    vm_resume(host, guest)
+    if is_acpi_state(host,guest,3):
+        raise VMResumeFailure()
+
+def sleep_vm_windows(host,guest):
+    vm_sleep_self(host, who=guest)
+    #due to use of exec-daemon in vm_sleep_self, can take time for it to finish
+	
+    if retry(
+        lambda: is_asleep(host,guest), description = 'checking if VM is asleep yet',
+        timeout = 120):
+        pass
+    vm_resume(host,guest)
+    vm_reinstate_hibernate(host, who=guest)	
+    """windows sleep commands like to go to hibernate instead, so after we done we need to reinstate them"""
+
+def sleep_to_shutdown(host,guest):
+    print "Attempting shutdown from sleep"
+    run(['xec-vm', '-n', guest, 'sleep'], host=host)
+    guest_shutdown(host, guest)
+    if is_acpi_state(host,guest,3):
+        raise VMResumeFailure()
+
+def test_sleep(host, url):
+
+    guest = 'sleeper'
+    path = get_vhd_from_url(host, url)
+    
+    create_vm_and_snapshot(host, guest, "sleeper test", path, "sleeper.vhd")
+
+    install_tools(host, guest)
+
+    start_vm_if_not_running(dut=host, guest=guest)
+    #might be off or hibernating
+    vm_resume(host, guest)
+    #incase it is already sleeping
+    sleep_dom0(host,guest)
+    os = get_system_type(host, guest)
+    print 'os is ' + os
+    #step 4.1 sleep from within host windows
+    if os == 'windows':
+        sleep_vm_windows(host,guest)
+	
+        #step 4.2 sleep from within host linux
+    elif os == 'linux':
+        print 'Linux not implemented yet'
+        vm_resume(host,guest)
+
+    else:
+        raise Exception("Unexpected OS: %s" % os)
+   
+    #make sure it can shutdown from sleep
+    sleep_to_shutdown(host,guest) 
+
+    #step 5 clean up (delete VM) if wanted
+	
+    """shutdown VM so it can be deleted"""
+    guest_destroy(host, guest)
+    if guest_state(host,guest) == 'stopped':
+        guest_delete(host, guest)
+        if guest_exists(host, guest):
+            raise VMDeleteionFailure()
+
+    print 'INFO: sleep test succeeded'	
+
+def entry_fn(dut, url):
+    test_sleep(dut, url)
+
+def desc():
+    return 'Checks how it handles sleeping and certain operations'


### PR DESCRIPTION
and implements two additional testcases.

[autolaunch.py]
  * Bug fixes, better error checking/handling

[bvt.py]
  * Improved checking for *.py files
  * New cmd line arg to set timelimit for testcases that require it.

[bvt_daemon.py]
  * Exception handling for ValueError, seen on some return codes.

[docs/README.md]
  * Section on setting up ddns and masquerading
  * more details on windows vm configuration with execdaemon
  * Notes that we support AMT v9.0 over the wsman protocol

[setup/00-install-prereqs.sh]
  * Fixed package version problem
  * added fetch for amtctrl tool used for wsman

[setup/03-install-dhcp-serv.sh]
  * Added optional dnssec-tools and bind9 pkgs for ddns

[src/bvtlib/call_exec_daemon.py]
  * Modified output to return similar to run.py, options to split
    on word or line.

[src/bvtlib/device_ops.py]
  * New module that performs operations on cd devices.

[src/bvtlib/disk_ops.py]
  * New module to perform operations on disks such as
    snapshotting, add/removing vhds, retrieve vhd name, is vhd valid, etc.

[src/bvtlib/guest_info.py]
  * Added new functions to query information about the guest
    (ram, stubdom, domid, vcpus, uuid, tools, etc)

[src/bvtlib/guest_ops.py]
  * Added new functions to support some of the new testcases.
  * Bug fixes in create_guest(), wrong param name

[src/bvtlib/host_ops.py]
  * New module to perform operations at the host level such as:
	mount debugfs, downloading vhds, reboot. New host functions should
	go in here as well.

[src/bvtlib/install_tools_windows.py]
  * Removed hard-coded username for windows vm, replaced with function
	to query the user.

[src/bvtlib/power_control.py]
  * Added wsman support for AMT v9.0+. Power control type can be set
	in mongodb for a DUT.

[src/bvtlib/record_test.py]
  * Slightly increase timeout to avoid exceptions.

[src/bvtlib/run.py]
  * Disable strict host key checking and known host file recording to
	make sshing to DUTs or bvt-controller more transparent

[src/bvtlib/windows_transitions.py]
  * Fix import so module name isn't required in function call
  * Added functions to support sleep_test testcase

[src/bvtlib/xen_info.py]
  * New module to query information from xenops

[src/testcases/cd_exclusive_test.py]
  * New testcase to ensure that cd devices can only be passed through
	to one guest at a time.

[src/testcases/sleep_test.py]
  * New testcase to verify that s3 works for guest and certain host operations
	function properly while a guest is in s3.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>